### PR TITLE
Fix type error and refactor code

### DIFF
--- a/src/Components/AppBar.php
+++ b/src/Components/AppBar.php
@@ -9,69 +9,69 @@ use MaterialBlade\Helper;
 
 class AppBar extends Component
 {
-  public ?string $title;
-  public ?string $variant;
-  public bool $isFixed;
-  public ?string $color;
+    public ?string $title;
+    public ?string $variant;
+    public bool $isFixed;
+    public ?string $color;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    bool $fixed = false,
-    ?string $title = null,
-    ?string $variant = null,
-    ?string $color = null
-  ) {
-    $this->isFixed = $fixed;
-    $this->title = $title;
-    $this->variant = $variant;
-    $this->color = $color;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::app-bar');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    if ($this->color) {
-      $attributes = $attributes->merge([
-        'style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))
-      ]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $fixed = false,
+        ?string $title = null,
+        ?string $variant = null,
+        ?string $color = null
+    ) {
+        $this->isFixed = $fixed;
+        $this->title = $title;
+        $this->variant = $variant;
+        $this->color = $color;
     }
-    
-    return $attributes->class([
-      'mdc-top-app-bar',
-      'mdc-top-app-bar--' . ($this->variant === 'short-collapsed' ? 'short mdc-top-app-bar--short-collapsed' : $this->variant) => $this->variant,
-      'mdc-top-app-bar--fixed' => $this->isFixed
-    ]);
-  }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::app-bar';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        if ($this->color) {
+            $attributes = $attributes->merge([
+                'style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))
+            ]);
+        }
+
+        return $attributes->class([
+            'mdc-top-app-bar',
+            'mdc-top-app-bar--' . ($this->variant === 'short-collapsed' ? 'short mdc-top-app-bar--short-collapsed' : $this->variant) => $this->variant,
+            'mdc-top-app-bar--fixed' => $this->isFixed
+        ]);
+    }
 
 
-  public function startAttributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-top-app-bar__section',
-      'mdc-top-app-bar__section--align-start'
-    ]);
-  }
+    public function startAttributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-top-app-bar__section',
+            'mdc-top-app-bar__section--align-start'
+        ]);
+    }
 
-  public function endAttributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['role' => $attributes->get('role', 'toolbar')]);
+    public function endAttributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['role' => $attributes->get('role', 'toolbar')]);
 
-    return $attributes->class([
-      'mdc-top-app-bar__section',
-      'mdc-top-app-bar__section--align-end'
-    ]);
-  }
+        return $attributes->class([
+            'mdc-top-app-bar__section',
+            'mdc-top-app-bar__section--align-end'
+        ]);
+    }
 }

--- a/src/Components/Assets.php
+++ b/src/Components/Assets.php
@@ -2,7 +2,6 @@
 
 namespace MaterialBlade\Components;
 
-
 use Illuminate\View\Component;
 
 class Assets extends Component
@@ -24,6 +23,6 @@ class Assets extends Component
      */
     public function render()
     {
-        return view('mbv::_assets');
+        return 'mbv::_assets';
     }
 }

--- a/src/Components/Banner.php
+++ b/src/Components/Banner.php
@@ -9,46 +9,46 @@ use MaterialBlade\Helper;
 
 class Banner extends Component
 {
-  public string $text;
-  public ?string $icon;
-  public ?string $actions;
-  public bool $isFixed;
+    public string $text;
+    public ?string $icon;
+    public ?string $actions;
+    public bool $isFixed;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $text,
-    bool $fixed = false,
-    ?string $icon = null,
-    ?string $actions = null
-  ) {
-    $this->text = $text;
-    $this->icon = $icon;
-    $this->actions = $actions;
-    $this->isFixed = $fixed;
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $text,
+        bool $fixed = false,
+        ?string $icon = null,
+        ?string $actions = null
+    ) {
+        $this->text = $text;
+        $this->icon = $icon;
+        $this->actions = $actions;
+        $this->isFixed = $fixed;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::banner');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::banner';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge([
-      'role' => 'banner'
-    ]);
-    
-    return $attributes->class([
-      'mdc-banner mdc-banner--mobile-stacked mdc-banner--centered'
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge([
+            'role' => 'banner'
+        ]);
+
+        return $attributes->class([
+            'mdc-banner mdc-banner--mobile-stacked mdc-banner--centered'
+        ]);
+    }
 }

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -2,82 +2,82 @@
 
 namespace MaterialBlade\Components;
 
-use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\ComponentSlot;
 use MaterialBlade\Helper;
 
 class Button extends Component
 {
-  public string $color;
-  public bool $isFullwidth;
-  public bool $isRipple;
-  public bool $withWrapper;
-  public ?string $endIcon;
-  public ?string $label;
-  // public string $size;
-  public ?string $startIcon;
-  public ?string $variant;
+    public string $color;
+    public bool $isFullwidth;
+    public bool $isRipple;
+    public bool $withWrapper;
+    public ?string $endIcon;
+    public ?string $label;
+    // public string $size;
+    public ?string $startIcon;
+    public ?string $variant;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    bool $fullwidth = false,
-    // string $size = null,
-    string $variant = 'text',
-    bool $withWrapper = false,
-    string $color = 'primary',
-    bool $disableRipple = false,
-    ?string $endIcon = null,
-    ?string $label = null,
-    ?string $startIcon = null
-  ) {
-    $this->color = $color;
-    $this->endIcon = $endIcon;
-    $this->isFullwidth = $fullwidth;
-    $this->label = $label;
-    $this->isRipple = !$disableRipple;
-    $this->startIcon = $startIcon;
-    $this->variant = $variant;
-    $this->withWrapper = $withWrapper;
-    // $this->size = $size;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return 'mbv::button';
-  }
-
-  public function validateComponent(HtmlString $slot)
-  {
-    if (!$this->label && $slot->isEmpty()) {
-      throw new \Exception('Please fill the "label" attribute or the component slot', 1);
-    }
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    if ($this->color !== 'primary') {
-      $attributes = $attributes->merge([
-        'style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))
-      ]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $fullwidth = false,
+        // string $size = null,
+        string $variant = 'text',
+        bool $withWrapper = false,
+        string $color = 'primary',
+        bool $disableRipple = false,
+        ?string $endIcon = null,
+        ?string $label = null,
+        ?string $startIcon = null
+    ) {
+        $this->color = $color;
+        $this->endIcon = $endIcon;
+        $this->isFullwidth = $fullwidth;
+        $this->label = $label;
+        $this->isRipple = !$disableRipple;
+        $this->startIcon = $startIcon;
+        $this->variant = $variant;
+        $this->withWrapper = $withWrapper;
+        // $this->size = $size;
     }
 
-    return $attributes->class([
-      'mdc-button',
-      'mdc-button--touch' => $this->withWrapper,
-      'mdc-button--' . ($this->variant) => $this->variant !== 'text' && in_array($this->variant, ['raised', 'unelevated', 'outlined']),
-      'mdc-button--icon-leading' => $this->startIcon ? true : false,
-      'mdc-button--icon-trailing' => $this->endIcon ? true : false,
-      'fullwidth' => $this->isFullwidth,
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::button';
+    }
+
+    public function validateComponent(ComponentSlot $slot)
+    {
+        if (!$this->label && $slot->isEmpty()) {
+            throw new \Exception('Please fill the "label" attribute or the component slot', 1);
+        }
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        if ($this->color !== 'primary') {
+            $attributes = $attributes->merge([
+                'style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))
+            ]);
+        }
+
+        return $attributes->class([
+            'mdc-button',
+            'mdc-button--touch' => $this->withWrapper,
+            'mdc-button--' . ($this->variant) => $this->variant !== 'text' && in_array($this->variant, ['raised', 'unelevated', 'outlined']),
+            'mdc-button--icon-leading' => $this->startIcon ? true : false,
+            'mdc-button--icon-trailing' => $this->endIcon ? true : false,
+            'fullwidth' => $this->isFullwidth,
+        ]);
+    }
 }

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -8,34 +8,34 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Card extends Component
 {
-  public string $variant;
+    public string $variant;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $variant = 'elevated'
-  ) {
-    $this->variant = $variant;
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $variant = 'elevated'
+    ) {
+        $this->variant = $variant;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::_plain-div');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::_plain-div';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-card',
-      'mdc-card--outlined' => $this->variant === 'outlined'
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-card',
+            'mdc-card--outlined' => $this->variant === 'outlined'
+        ]);
+    }
 }

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -5,10 +5,21 @@ namespace MaterialBlade\Components;
 
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
+use MaterialBlade\Components\Card\Enums\Variant;
 
+/**
+ * @property Variant $variant
+ * 
+ * @see https://mui.com/material-ui/react-card/
+ * @see https://m2.material.io/components/cards
+ * @see https://material-components.github.io/material-components-web-catalog/#/component/elevation
+ * @see https://github.com/material-components/material-components-web/tree/v14.0.0/packages/mdc-elevation
+ * @see https://material-components.github.io/material-components-web-catalog/#/component/card
+ * @see https://github.com/material-components/material-components-web/tree/v14.0.0/packages/mdc-card
+ */
 class Card extends Component
 {
-    public string $variant;
+    public Variant $variant = Variant::ELEVATED;
 
     /**
      * Create a new component instance.
@@ -16,9 +27,11 @@ class Card extends Component
      * @return void
      */
     public function __construct(
-        string $variant = 'elevated'
+        string $variant = null
     ) {
-        $this->variant = $variant;
+        if ($variant) {
+            $this->variant = Variant::from($variant);
+        }
     }
 
     /**
@@ -35,7 +48,7 @@ class Card extends Component
     {
         return $attributes->class([
             'mdc-card',
-            'mdc-card--outlined' => $this->variant === 'outlined'
+            'mdc-card--outlined' => $this->variant === Variant::OUTLINED
         ]);
     }
 }

--- a/src/Components/Card/Enums/Variant.php
+++ b/src/Components/Card/Enums/Variant.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MaterialBlade\Components\Card\Enums;
+
+enum Variant: string
+{
+    case ELEVATED = 'elevated';
+    case OUTLINED = 'outlined';
+}

--- a/src/Components/CardActions.php
+++ b/src/Components/CardActions.php
@@ -9,29 +9,29 @@ use Illuminate\View\ComponentAttributeBag;
 class CardActions extends Component
 {
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct()
-  {
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::card-actions');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::card-actions';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-card__actions'
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-card__actions'
+        ]);
+    }
 }

--- a/src/Components/CardContent.php
+++ b/src/Components/CardContent.php
@@ -7,30 +7,30 @@ use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
 
 class CardContent extends Component
-{  
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct()
-  {
-  }
+{
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::_plain-div');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::_plain-div';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-card__content'
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-card__content'
+        ]);
+    }
 }

--- a/src/Components/CardHeader.php
+++ b/src/Components/CardHeader.php
@@ -8,42 +8,42 @@ use Illuminate\View\ComponentAttributeBag;
 
 class CardHeader extends Component
 {
-  public string $title;
-  public string $titleElement;
-  public string $subtitle;
-  public string $subtitleElement;
+    public string $title;
+    public string $titleElement;
+    public string $subtitle;
+    public string $subtitleElement;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $title,
-    ?string $subtitle = null,
-    string $titleElement = 'div',
-    string $subtitleElement = 'div'
-  ) {
-    $this->title = $title;
-    $this->subtitle = $subtitle;
-    $this->titleElement = $titleElement;
-    $this->subtitleElement = $subtitleElement;
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $title,
+        ?string $subtitle = null,
+        string $titleElement = 'div',
+        string $subtitleElement = 'div'
+    ) {
+        $this->title = $title;
+        $this->subtitle = $subtitle;
+        $this->titleElement = $titleElement;
+        $this->subtitleElement = $subtitleElement;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::card-header');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::card-header';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-card__header'
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-card__header'
+        ]);
+    }
 }

--- a/src/Components/CardMedia.php
+++ b/src/Components/CardMedia.php
@@ -9,37 +9,37 @@ use Illuminate\View\ComponentAttributeBag;
 class CardMedia extends Component
 {
 
-  public string $src;
-  public string $variant;
-  
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(string $src, string $variant = '16-9')
-  {
-    $this->src = $src;
-    $this->variant = $variant;
-  }
+    public string $src;
+    public string $variant;
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::card-media');
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(string $src, string $variant = '16-9')
+    {
+        $this->src = $src;
+        $this->variant = $variant;
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['style' => $attributes->prepends('background-image: url(\'' .  $this->src . '\');')]);
-    
-    return $attributes->class([
-      'mdc-card__media',
-      'mdc-card__media--' . $this->variant
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::card-media';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['style' => $attributes->prepends('background-image: url(\'' .  $this->src . '\');')]);
+
+        return $attributes->class([
+            'mdc-card__media',
+            'mdc-card__media--' . $this->variant
+        ]);
+    }
 }

--- a/src/Components/CardPrimaryAction.php
+++ b/src/Components/CardPrimaryAction.php
@@ -8,31 +8,31 @@ use Illuminate\View\ComponentAttributeBag;
 
 class CardPrimaryAction extends Component
 {
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct()
-  {
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::card-primary-action');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::card-primary-action';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['tabindex' => 0]);
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['tabindex' => 0]);
 
-    return $attributes->class([
-      'mdc-card__primary-action'
-    ]);
-  }
+        return $attributes->class([
+            'mdc-card__primary-action'
+        ]);
+    }
 }

--- a/src/Components/Checkbox.php
+++ b/src/Components/Checkbox.php
@@ -8,46 +8,46 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Checkbox extends Component
 {
-  public ?string $color;
-  public ?string $label;
-  public bool $isIndeterminate;
-  // public bool $isDisabled;
+    public ?string $color;
+    public ?string $label;
+    public bool $isIndeterminate;
+    // public bool $isDisabled;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    bool $indeterminate = false,
-    string $color = 'primary',
-    ?string $label = null
-  ) {
-    $this->color = $color;
-    $this->label = $label;
-    $this->isIndeterminate = $indeterminate;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::checkbox');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['type' => 'checkbox']);
-
-    if ($this->isIndeterminate) {
-      $attributes = $attributes->merge(['data-indeterminate' => 'true']);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $indeterminate = false,
+        string $color = 'primary',
+        ?string $label = null
+    ) {
+        $this->color = $color;
+        $this->label = $label;
+        $this->isIndeterminate = $indeterminate;
     }
 
-    return $attributes->class([
-      'mdc-checkbox__native-control'
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::checkbox';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['type' => 'checkbox']);
+
+        if ($this->isIndeterminate) {
+            $attributes = $attributes->merge(['data-indeterminate' => 'true']);
+        }
+
+        return $attributes->class([
+            'mdc-checkbox__native-control'
+        ]);
+    }
 }

--- a/src/Components/Chip.php
+++ b/src/Components/Chip.php
@@ -8,49 +8,49 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Chip extends Component
 {
-  public string $label;
-  public ?string $icon;
-  public bool $isSelected;
-  public bool $isWithWrapper;
-  public bool $isDisabled;
+    public string $label;
+    public ?string $icon;
+    public bool $isSelected;
+    public bool $isWithWrapper;
+    public bool $isDisabled;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $label,
-    ?string $icon = null,
-    bool $selected = false,
-    bool $withWrapper = false,
-    bool $disabled = false
-  ) {
-    $this->label = $label;
-    $this->icon = $icon;
-    $this->isSelected = $selected;
-    $this->isWithWrapper = $withWrapper;
-    $this->isDisabled = $disabled;
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $label,
+        ?string $icon = null,
+        bool $selected = false,
+        bool $withWrapper = false,
+        bool $disabled = false
+    ) {
+        $this->label = $label;
+        $this->icon = $icon;
+        $this->isSelected = $selected;
+        $this->isWithWrapper = $withWrapper;
+        $this->isDisabled = $disabled;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::chip');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::chip';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['role' => 'row']);
-    
-    return $attributes->class([
-      'mdc-chip',
-      'mdc-chip--selected' => $this->isSelected,
-      'mdc-chip--touch' => $this->isWithWrapper
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['role' => 'row']);
+
+        return $attributes->class([
+            'mdc-chip',
+            'mdc-chip--selected' => $this->isSelected,
+            'mdc-chip--touch' => $this->isWithWrapper
+        ]);
+    }
 }

--- a/src/Components/ChipSet.php
+++ b/src/Components/ChipSet.php
@@ -8,37 +8,37 @@ use Illuminate\View\ComponentAttributeBag;
 
 class ChipSet extends Component
 {
-  public string $variant;
+    public string $variant;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $variant = 'basic'
-  ) {
-    $this->variant = $variant;
-  }
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $variant = 'basic'
+    ) {
+        $this->variant = $variant;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::chip-set');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::chip-set';
+    }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge(['role' => 'grid']);
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge(['role' => 'grid']);
 
-    
-    return $attributes->class([
-      'mdc-chip-set',
-      'mdc-chip-set--' . $this->variant =>  $this->variant !== 'basic',
-    ]);
-  }
+
+        return $attributes->class([
+            'mdc-chip-set',
+            'mdc-chip-set--' . $this->variant =>  $this->variant !== 'basic',
+        ]);
+    }
 }

--- a/src/Components/CircularProgress.php
+++ b/src/Components/CircularProgress.php
@@ -9,60 +9,60 @@ use MaterialBlade\Helper;
 
 class CircularProgress extends Component
 {
-  public string $color;
-  public string $size;
-  public ?float $value;
+    public string $color;
+    public string $size;
+    public ?float $value;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $color = 'primary',
-    string $size = '48px',
-    ?float $value = null
-  ) {
-    $this->color = $color;
-    $this->value = $value;
-    $this->size = $size;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::circular-progress');
-  }
-
-  private function validateComponent(ComponentAttributeBag $attributes)
-  {
-    if (!$attributes->has('aria-label')) {
-      throw new \Exception('Progress bars is conform to the WAI-ARIA Progressbar Specification, the \'aria-label\' attribute is required');
-    }
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $this->validateComponent($attributes);
-
-    $attributes = $attributes->merge([
-      'role' => 'progressbar',
-      'aria-valuemin' => 0,
-      'aria-valuemax'=> 1,
-      'aria-valuenow' => $this->value ?: 0
-    ]);
-
-    if ($this->color !== 'primary') {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $color = 'primary',
+        string $size = '48px',
+        ?float $value = null
+    ) {
+        $this->color = $color;
+        $this->value = $value;
+        $this->size = $size;
     }
 
-    return $attributes->class([
-      'mdc-circular-progress',
-      'mdc-circular-progress--indeterminate' => $this->value === null,
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::circular-progress';
+    }
+
+    private function validateComponent(ComponentAttributeBag $attributes)
+    {
+        if (!$attributes->has('aria-label')) {
+            throw new \Exception('Progress bars is conform to the WAI-ARIA Progressbar Specification, the \'aria-label\' attribute is required');
+        }
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $this->validateComponent($attributes);
+
+        $attributes = $attributes->merge([
+            'role' => 'progressbar',
+            'aria-valuemin' => 0,
+            'aria-valuemax' => 1,
+            'aria-valuenow' => $this->value ?: 0
+        ]);
+
+        if ($this->color !== 'primary') {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+        }
+
+        return $attributes->class([
+            'mdc-circular-progress',
+            'mdc-circular-progress--indeterminate' => $this->value === null,
+        ]);
+    }
 }

--- a/src/Components/Container.php
+++ b/src/Components/Container.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MaterialBlade\Components;
+
+
+use Illuminate\View\Component;
+use Illuminate\View\ComponentAttributeBag;
+
+class Container extends Component
+{
+    public string $maxWidth;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $maxWidth = 'md'
+    ) {
+        $this->maxWidth = $maxWidth;
+
+        $this->validateProps();
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::_plain-div';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mbc-container',
+            'mbc-container--' . $this->maxWidth
+        ]);
+    }
+
+    private function validateProps()
+    {
+        $this->validateMaxWidth($this->maxWidth);
+    }
+
+    private function validateMaxWidth(string $maxWidth)
+    {
+        $allowedMaxWidths = ['xs', 'sm', 'md', 'lg', 'xl'];
+        if (!in_array($maxWidth, $allowedMaxWidths)) {
+            throw new \Exception('Invalid max width value. Allowed values are: ' . implode(', ', $allowedMaxWidths));
+        }
+    }
+}

--- a/src/Components/DataTable.php
+++ b/src/Components/DataTable.php
@@ -8,31 +8,31 @@ use Illuminate\View\ComponentAttributeBag;
 
 class DataTable extends Component
 {
-  public bool $isWithCheckbox;
-  public array $header;
-  public array $tableData;
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    bool $withCheckbox = false,
-    array $header = [],
-    array $data = []
-  ) {
-    $this->isWithCheckbox = $withCheckbox;
-    $this->tableData = $data;
-    $this->header = $header;
-  }
+    public bool $isWithCheckbox;
+    public array $header;
+    public array $tableData;
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $withCheckbox = false,
+        array $header = [],
+        array $data = []
+    ) {
+        $this->isWithCheckbox = $withCheckbox;
+        $this->tableData = $data;
+        $this->header = $header;
+    }
 
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::data-table');
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::data-table';
+    }
 }

--- a/src/Components/FAB.php
+++ b/src/Components/FAB.php
@@ -9,69 +9,69 @@ use MaterialBlade\Helper;
 
 class FAB extends Component
 {
-  public string $variant;
-  public bool $isWithWrapper;
-  public ?string $iconString;
-  public ?string $color;
-  public ?string $label;
+    public string $variant;
+    public bool $isWithWrapper;
+    public ?string $iconString;
+    public ?string $color;
+    public ?string $label;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $variant = 'regular',
-    string $color = 'secondary',
-    bool $withWrapper = false,
-    ?string $icon = null,
-    ?string $label = null
-  ) {
-    $this->iconString = $icon;
-    $this->variant = $variant;
-    $this->color = $color;
-    $this->isWithWrapper = $withWrapper;
-    $this->label = $label;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::fab');
-  }
-
-  public function validateComponent()
-  {
-    if ($this->variant === 'mini' && $this->label) {
-      throw new \Exception('"mini" variant can\'t have a label', 1);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $variant = 'regular',
+        string $color = 'secondary',
+        bool $withWrapper = false,
+        ?string $icon = null,
+        ?string $label = null
+    ) {
+        $this->iconString = $icon;
+        $this->variant = $variant;
+        $this->color = $color;
+        $this->isWithWrapper = $withWrapper;
+        $this->label = $label;
     }
 
-    if (!$this->iconString && !$this->label) {
-      throw new \Exception('please add the \'icon\' or \'label\' props', 1);
-    }
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $this->validateComponent();
-
-    $attributes = $attributes->merge([
-      'aria-label' => ucfirst(Helper::parseIconString($this->iconString)[0])
-    ]);
-
-    if ($this->color !== 'secondary') {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-secondary: ' . Helper::getColor($this->color))]);
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::fab';
     }
 
-    return $attributes->class([
-      'mdc-fab',
-      'mdc-fab--mini' => $this->variant === 'mini',
-      'mdc-fab--extended' => $this->label,
-      'mdc-fab--touch' => $this->isWithWrapper
-    ]);
-  }
+    public function validateComponent()
+    {
+        if ($this->variant === 'mini' && $this->label) {
+            throw new \Exception('"mini" variant can\'t have a label', 1);
+        }
+
+        if (!$this->iconString && !$this->label) {
+            throw new \Exception('please add the \'icon\' or \'label\' props', 1);
+        }
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $this->validateComponent();
+
+        $attributes = $attributes->merge([
+            'aria-label' => ucfirst(Helper::parseIconString($this->iconString)[0])
+        ]);
+
+        if ($this->color !== 'secondary') {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-secondary: ' . Helper::getColor($this->color))]);
+        }
+
+        return $attributes->class([
+            'mdc-fab',
+            'mdc-fab--mini' => $this->variant === 'mini',
+            'mdc-fab--extended' => $this->label,
+            'mdc-fab--touch' => $this->isWithWrapper
+        ]);
+    }
 }

--- a/src/Components/Grid.php
+++ b/src/Components/Grid.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace MaterialBlade\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\ComponentAttributeBag;
+
+/**
+ * @see https://m2.material.io/develop/web/supporting/layout-grid
+ * @see https://material-components.github.io/material-components-web-catalog/#/component/layout-grid
+ * @see https://mui.com/material-ui/react-grid2/
+ */
+class Grid extends Component
+{
+    private bool $isContainer;
+    private int $colSize;
+    private string $align;
+    private float $padding;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $container = false,
+        float $padding = 0,
+        int $colSize = 4,
+        string $align = null
+    ) {
+        $this->isContainer = $container;
+        $this->colSize = $colSize;
+        $this->align = $align ?? ($this->isContainer ? 'left' : 'top');
+        $this->padding = $padding;
+
+        $this->validateProps();
+    }
+
+    private function validateProps()
+    {
+        $this->validateColSizeProp();
+        $this->validateAlignProp();
+        $this->validatePaddingProp();
+    }
+
+    private function validateColSizeProp()
+    {
+        if ($this->colSize < 1 || $this->colSize > 12) {
+            throw new \Exception('Column size must be between 1 and 12');
+        }
+    }
+
+    private function validateAlignProp()
+    {
+        $itemValidAlign = ['top', 'middle', 'bottom'];
+        $containerValidAlign = ['left', 'right', 'center'];
+
+        if (!in_array($this->align, $this->isContainer ? $containerValidAlign : $itemValidAlign)) {
+            throw new \Exception('Invalid align property, must be one of: ' . implode(', ', $this->isContainer ? $containerValidAlign : $itemValidAlign));
+        }
+    }
+
+    private function validatePaddingProp()
+    {
+        if ($this->padding < 0) {
+            throw new \Exception('Padding must be a positive number');
+        }
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        if ($this->isContainer) {
+            return 'mbv::grid.container';
+        }
+
+        return 'mbv::grid.item';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->style([
+            'padding: ' . ($this->padding * 16) . 'px',
+        ])->class(
+            $this->isContainer ? [
+                'mdc-layout-grid',
+                'mdc-layout-grid--align-' . $this->align,
+            ] : [
+                'mdc-layout-grid__cell',
+                'mdc-layout-grid__cell--span-' . $this->colSize,
+                'mdc-layout-grid__cell--align-' . $this->align,
+            ]
+        );
+    }
+}

--- a/src/Components/Icon.php
+++ b/src/Components/Icon.php
@@ -9,49 +9,49 @@ use MaterialBlade\Helper;
 
 class Icon extends Component
 {
-  public ?string $color;
-  public string $icon;
-  public string $variant;
-  // public $size;
+    public ?string $color;
+    public string $icon;
+    public string $variant;
+    // public $size;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $icon,
-    ?string $color = null,
-    string $variant = 'filled'
-    // string $size = null,
-  ) {
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $icon,
+        ?string $color = null,
+        string $variant = 'filled'
+        // string $size = null,
+    ) {
 
-    [$icon, $variantTemp] = Helper::parseIconString($icon);
+        [$icon, $variantTemp] = Helper::parseIconString($icon);
 
-    $this->icon = $icon;
-    $this->variant = $variantTemp ?: $variant;
-    $this->color = $color;
-    // $this->size = $size;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::icon');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    if ($this->color) {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('color: ' . Helper::getColor($this->color) . ';')]);
+        $this->icon = $icon;
+        $this->variant = $variantTemp ?: $variant;
+        $this->color = $color;
+        // $this->size = $size;
     }
 
-    return $attributes->class([
-      'material-icons' . ($this->variant != 'filled' ? '-' . $this->variant : '')
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::icon';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        if ($this->color) {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('color: ' . Helper::getColor($this->color) . ';')]);
+        }
+
+        return $attributes->class([
+            'material-icons' . ($this->variant != 'filled' ? '-' . $this->variant : '')
+        ]);
+    }
 }

--- a/src/Components/IconButton.php
+++ b/src/Components/IconButton.php
@@ -8,64 +8,65 @@ use Illuminate\View\ComponentAttributeBag;
 
 class IconButton extends Component
 {
-  public string $icon;
-  public bool $isRipple;
-  public bool $isWithWrapper;
-  public ?string $color;
-  public ?bool $isToggle;
-  public ?string $offIcon;
-  public ?string $offColor;
+    public string $icon;
+    public bool $isRipple;
+    public bool $isWithWrapper;
+    public ?string $color;
+    public ?bool $isToggle;
+    public ?string $offIcon;
+    public ?string $offColor;
 
-  // public $size;
+    // public $size;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $icon,
-    string $color = 'var(--mdc-theme-text-secondary-on-light)',
-    string $offColor = 'var(--mdc-theme-text-secondary-on-light)',
-    bool $disableRipple = false,
-    bool $withWrapper = false,
-    ?string $toggle = null,
-    ?string $offIcon = null
-    // string $size = null
-  ) {
-    $this->color = $color;
-    $this->isToggle = is_null($toggle) ? null : ($toggle == 'on' ? true : false);
-    $this->icon = $icon;
-    $this->offIcon = $offIcon;
-    $this->offColor = $offColor;
-    $this->isRipple = !$disableRipple;
-    $this->isWithWrapper = $withWrapper;
-    // $this->size = $size;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::icon-button');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes) {
-    $attributes = $attributes->class([
-      'mdc-icon-button',
-      'mdc-icon-button--touch' => $this->isWithWrapper,
-      'mdc-icon-button--on' => $this->isToggle
-    ]);
-    
-    $attributes = $attributes->merge(['aria-label' => $this->icon]);
-    
-    if (! is_null($this->isToggle)) {
-        $attributes = $attributes->merge(['aria-pressed' => $this->isToggle]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $icon,
+        string $color = 'var(--mdc-theme-text-secondary-on-light)',
+        string $offColor = 'var(--mdc-theme-text-secondary-on-light)',
+        bool $disableRipple = false,
+        bool $withWrapper = false,
+        ?string $toggle = null,
+        ?string $offIcon = null
+        // string $size = null
+    ) {
+        $this->color = $color;
+        $this->isToggle = is_null($toggle) ? null : ($toggle == 'on' ? true : false);
+        $this->icon = $icon;
+        $this->offIcon = $offIcon;
+        $this->offColor = $offColor;
+        $this->isRipple = !$disableRipple;
+        $this->isWithWrapper = $withWrapper;
+        // $this->size = $size;
     }
 
-    return $attributes;
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::icon-button';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->class([
+            'mdc-icon-button',
+            'mdc-icon-button--touch' => $this->isWithWrapper,
+            'mdc-icon-button--on' => $this->isToggle
+        ]);
+
+        $attributes = $attributes->merge(['aria-label' => $this->icon]);
+
+        if (!is_null($this->isToggle)) {
+            $attributes = $attributes->merge(['aria-pressed' => $this->isToggle]);
+        }
+
+        return $attributes;
+    }
 }

--- a/src/Components/LinearProgress.php
+++ b/src/Components/LinearProgress.php
@@ -9,66 +9,66 @@ use MaterialBlade\Helper;
 
 class LinearProgress extends Component
 {
-  public string $color;
-  public ?float $value;
-  public ?float $bufferValue;
+    public string $color;
+    public ?float $value;
+    public ?float $bufferValue;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $color = 'primary',
-    ?float $value = null,
-    ?float $bufferValue = null
-  ) {
-    $this->color = $color;
-    $this->value = $value;
-    $this->bufferValue = $bufferValue;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::linear-progress');
-  }
-
-  private function validateComponent(ComponentAttributeBag $attributes)
-  {
-    if (!$attributes->has('aria-label')) {
-      throw new \Exception('Progress bars is conform to the WAI-ARIA Progressbar Specification, the \'aria-label\' attribute is required');
-    }
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $this->validateComponent($attributes);
-
-    $attributes = $attributes->merge([
-      'role' => 'progressbar',
-      'aria-valuemin' => 0,
-      'aria-valuemax'=> 1,
-      'aria-valuenow' => $this->value ?: 0
-    ]);
-
-    if ($this->bufferValue !== null) {
-      $attributes = $attributes->merge([
-        'data-buffer-value' => $this->bufferValue
-      ]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $color = 'primary',
+        ?float $value = null,
+        ?float $bufferValue = null
+    ) {
+        $this->color = $color;
+        $this->value = $value;
+        $this->bufferValue = $bufferValue;
     }
 
-    if ($this->color !== 'primary') {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::linear-progress';
     }
 
-    return $attributes->class([
-      'mdc-linear-progress',
-      'mdc-linear-progress--indeterminate' => $this->value === null,
-    ]);
-  }
+    private function validateComponent(ComponentAttributeBag $attributes)
+    {
+        if (!$attributes->has('aria-label')) {
+            throw new \Exception('Progress bars is conform to the WAI-ARIA Progressbar Specification, the \'aria-label\' attribute is required');
+        }
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $this->validateComponent($attributes);
+
+        $attributes = $attributes->merge([
+            'role' => 'progressbar',
+            'aria-valuemin' => 0,
+            'aria-valuemax' => 1,
+            'aria-valuenow' => $this->value ?: 0
+        ]);
+
+        if ($this->bufferValue !== null) {
+            $attributes = $attributes->merge([
+                'data-buffer-value' => $this->bufferValue
+            ]);
+        }
+
+        if ($this->color !== 'primary') {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+        }
+
+        return $attributes->class([
+            'mdc-linear-progress',
+            'mdc-linear-progress--indeterminate' => $this->value === null,
+        ]);
+    }
 }

--- a/src/Components/Snackbar.php
+++ b/src/Components/Snackbar.php
@@ -9,44 +9,44 @@ use MaterialBlade\Helper;
 
 class Snackbar extends Component
 {
-  public string $variant;
-  public ?string $message;
+    public string $variant;
+    public ?string $message;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $variant = 'default',
-    ?string $message = null
-  ) {
-    $this->variant = $variant;
-    $this->message = $message;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::snackbar');
-  }
-
-  public function validateComponent(HtmlString $slot)
-  {
-    if (!$this->message && $slot->isEmpty()) {
-      throw new \Exception('Please fill the "message" attribute or the component slot', 1);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $variant = 'default',
+        ?string $message = null
+    ) {
+        $this->variant = $variant;
+        $this->message = $message;
     }
-  }
 
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-snackbar',
-      "mdc-snackbar--$this->variant" => $this->variant !== 'default',
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::snackbar';
+    }
+
+    public function validateComponent(HtmlString $slot)
+    {
+        if (!$this->message && $slot->isEmpty()) {
+            throw new \Exception('Please fill the "message" attribute or the component slot', 1);
+        }
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-snackbar',
+            "mdc-snackbar--$this->variant" => $this->variant !== 'default',
+        ]);
+    }
 }

--- a/src/Components/SwitchToggle.php
+++ b/src/Components/SwitchToggle.php
@@ -9,53 +9,53 @@ use MaterialBlade\Helper;
 
 class SwitchToggle extends Component
 {
-  public string $color;
-  public bool $isOn;
-  public ?string $icon;
-  public ?string $offIcon;
+    public string $color;
+    public bool $isOn;
+    public ?string $icon;
+    public ?string $offIcon;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    string $color = 'primary',
-    bool $on = false,
-    ?string $icon = null,
-    ?string $offIcon = null
-  ) {
-    $this->color = $color;
-    $this->isOn = $on;
-    $this->icon = $icon;
-    $this->offIcon = $offIcon;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::switch');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    $attributes = $attributes->merge([      
-      'type' => 'button',
-      'role' => 'switch',
-      'aria-checked' => $this->isOn
-    ]);
-
-    if ($this->color !== 'primary') {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $color = 'primary',
+        bool $on = false,
+        ?string $icon = null,
+        ?string $offIcon = null
+    ) {
+        $this->color = $color;
+        $this->isOn = $on;
+        $this->icon = $icon;
+        $this->offIcon = $offIcon;
     }
 
-    return $attributes->class([
-      'mdc-switch',
-      'mdc-switch--' . ($this->isOn ? 'selected' : 'unselected'),
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::switch';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        $attributes = $attributes->merge([
+            'type' => 'button',
+            'role' => 'switch',
+            'aria-checked' => $this->isOn
+        ]);
+
+        if ($this->color !== 'primary') {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('--mdc-theme-primary: ' . Helper::getColor($this->color))]);
+        }
+
+        return $attributes->class([
+            'mdc-switch',
+            'mdc-switch--' . ($this->isOn ? 'selected' : 'unselected'),
+        ]);
+    }
 }

--- a/src/Components/TabBar.php
+++ b/src/Components/TabBar.php
@@ -9,63 +9,63 @@ use MaterialBlade\Helper;
 
 class TabBar extends Component
 {
-  public array $tabs;
-  public string $color;
-  public bool $isFadeIndicator;
-  public bool $isIconOnly;
-  public bool $isStacked;
-  public bool $isLightText;
-  public ?int $activeTabNo;
-  public ?int $elevation;
-  public ?string $indicatorIcon;
+    public array $tabs;
+    public string $color;
+    public bool $isFadeIndicator;
+    public bool $isIconOnly;
+    public bool $isStacked;
+    public bool $isLightText;
+    public ?int $activeTabNo;
+    public ?int $elevation;
+    public ?string $indicatorIcon;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    array $tabs,
-    string $color = 'initial',
-    bool $fadeIndicator = false,
-    bool $iconOnly = false,
-    bool $stacked = false,
-    bool $lightText = false,
-    ?int $activeTabNo = null,
-    ?int $elevation = null,
-    ?string $indicatorIcon = null
-  ) {
-    $this->tabs = $tabs;
-    $this->color = $color;
-    $this->isLightText = $lightText;
-    $this->isFadeIndicator = $fadeIndicator;
-    $this->isIconOnly = $iconOnly;
-    $this->isStacked = $stacked;
-    $this->activeTabNo = $activeTabNo;
-    $this->indicatorIcon = $indicatorIcon;
-    $this->elevation = $elevation;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::tab-bar');
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    if ($this->color !== 'initial') {
-      $attributes = $attributes->merge(['style' => $attributes->prepends('background-color: ' . Helper::getColor($this->color))]);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        array $tabs,
+        string $color = 'initial',
+        bool $fadeIndicator = false,
+        bool $iconOnly = false,
+        bool $stacked = false,
+        bool $lightText = false,
+        ?int $activeTabNo = null,
+        ?int $elevation = null,
+        ?string $indicatorIcon = null
+    ) {
+        $this->tabs = $tabs;
+        $this->color = $color;
+        $this->isLightText = $lightText;
+        $this->isFadeIndicator = $fadeIndicator;
+        $this->isIconOnly = $iconOnly;
+        $this->isStacked = $stacked;
+        $this->activeTabNo = $activeTabNo;
+        $this->indicatorIcon = $indicatorIcon;
+        $this->elevation = $elevation;
     }
 
-    $attributes = $attributes->merge(['role' => 'tablist']);
-    return $attributes->class([
-      'mdc-tab-bar',
-      'mdc-elevation--z' . $this->elevation => $this->elevation
-    ]);
-  }
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::tab-bar';
+    }
+
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        if ($this->color !== 'initial') {
+            $attributes = $attributes->merge(['style' => $attributes->prepends('background-color: ' . Helper::getColor($this->color))]);
+        }
+
+        $attributes = $attributes->merge(['role' => 'tablist']);
+        return $attributes->class([
+            'mdc-tab-bar',
+            'mdc-elevation--z' . $this->elevation => $this->elevation
+        ]);
+    }
 }

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -8,90 +8,88 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Tooltip extends Component
 {
-  public ?string $title;
-  public string $id;
-  public string $isPersistent;
-  // public $size;
+    public ?string $title;
+    public string $id;
+    public string $isPersistent;
+    // public $size;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    bool $persistent = false,
-    ?string $title = null,
-    ?string $id = null
-  ) {
-    $this->title = $title;
-    $this->id = $id ?: uniqid();
-    $this->isPersistent = $persistent;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return function (array $data) {
-      $this->componentValidation($data);
-      return 'mbv::tooltip';
-    };
-  }
-
-  public function componentValidation(array $data)
-  {
-    if ($this->isPersistent && !isset($data['body'])) {
-      throw new \Exception('"Persistent" only work on Rich Tooltip', 1);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        bool $persistent = false,
+        ?string $title = null,
+        ?string $id = null
+    ) {
+        $this->title = $title;
+        $this->id = $id ?: uniqid();
+        $this->isPersistent = $persistent;
     }
 
-    if(isset($data['title']) && $data['attributes']->has('title')) {
-      throw new \Exception('"title" duplicated please choose one', 1);
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return function (array $data) {
+            $this->componentValidation($data);
+            return 'mbv::tooltip';
+        };
     }
 
-    
-  }
+    public function componentValidation(array $data)
+    {
+        if ($this->isPersistent && !isset($data['body'])) {
+            throw new \Exception('"Persistent" only work on Rich Tooltip', 1);
+        }
 
-  public function childPreprocess(string $slotString)
-  {
-
-    $isAriaLabelEqualTitle = stripos($slotString, 'aria-label="' . $this->title . '"');
-
-    $slotStrings = explode("\r\n", $slotString);
-
-    $prependAttr = ' aria-describedby="' . $this->id . '"';
-    if ($isAriaLabelEqualTitle) {
-      $prependAttr = ' data-tooltip-id="' . $this->id . '" data-hide-tooltip-from-screenreader="true"';
+        if (isset($data['title']) && $data['attributes']->has('title')) {
+            throw new \Exception('"title" duplicated please choose one', 1);
+        }
     }
 
-    $slotStrings[0] = str_replace('>', $prependAttr . '>', $slotStrings[0]);
+    public function childPreprocess(string $slotString)
+    {
 
-    return implode("\r\n", $slotStrings);
-  }
+        $isAriaLabelEqualTitle = stripos($slotString, 'aria-label="' . $this->title . '"');
 
+        $slotStrings = explode("\r\n", $slotString);
 
-  /**
-   * 
-   *
-   * @return ComponentAttributeBag
-   */
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    if ($this->isPersistent) {
-      $attributes = $attributes->merge([
-        'tabindex' => -1,
-        'data-mdc-tooltip-persistent' => "true"
-      ]);
+        $prependAttr = ' aria-describedby="' . $this->id . '"';
+        if ($isAriaLabelEqualTitle) {
+            $prependAttr = ' data-tooltip-id="' . $this->id . '" data-hide-tooltip-from-screenreader="true"';
+        }
+
+        $slotStrings[0] = str_replace('>', $prependAttr . '>', $slotStrings[0]);
+
+        return implode("\r\n", $slotStrings);
     }
 
-    return $attributes->class([
-      'mdc-tooltip'
-    ])->merge([
-      'id' => $this->id,
-      'role' => $attributes->prepends($this->isPersistent ? 'dialog' : 'tooltip'),
-      'aria-hidden' => $attributes->prepends('true')
-    ]);
-  }
+
+    /**
+     * 
+     *
+     * @return ComponentAttributeBag
+     */
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        if ($this->isPersistent) {
+            $attributes = $attributes->merge([
+                'tabindex' => -1,
+                'data-mdc-tooltip-persistent' => "true"
+            ]);
+        }
+
+        return $attributes->class([
+            'mdc-tooltip'
+        ])->merge([
+            'id' => $this->id,
+            'role' => $attributes->prepends($this->isPersistent ? 'dialog' : 'tooltip'),
+            'aria-hidden' => $attributes->prepends('true')
+        ]);
+    }
 }

--- a/src/Components/Typography.php
+++ b/src/Components/Typography.php
@@ -60,9 +60,10 @@ class Typography extends Component
 
     public function attributesPreprocess(ComponentAttributeBag $attributes)
     {
-        return $attributes->class([
-            'mbc-typography',
-            'mbc-typography--gutter-bottom' => !$this->disableGutter,
+        return $attributes->style([
+            'margin: 0',
+            'margin-bottom: 0.35em' => !$this->disableGutter
+        ])->class([
             'mdc-typography' . ($this->variant ? '--' . $this->variant : null)
         ]);
     }

--- a/src/Components/Typography.php
+++ b/src/Components/Typography.php
@@ -8,6 +8,7 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Typography extends Component
 {
+    public bool $gutterBottom;
     public ?string $element;
     public ?string $variant;
     public ?string $propSlot;
@@ -18,6 +19,7 @@ class Typography extends Component
      * @return void
      */
     public function __construct(
+        bool $gutterBottom = false,
         ?string $element = null,
         ?string $slot = null,
         ?string $variant = null
@@ -25,6 +27,7 @@ class Typography extends Component
         [$elementTemp, $variant] = $this->variantPreprocess($variant);
 
         $this->element = $element ?: $elementTemp;
+        $this->gutterBottom = $gutterBottom;
         $this->variant = $variant;
         $this->propSlot = $slot;
     }
@@ -60,6 +63,8 @@ class Typography extends Component
     public function attributesPreprocess(ComponentAttributeBag $attributes)
     {
         return $attributes->class([
+            'mbc-typography',
+            'mbc-typography--gutter-bottom' => $this->gutterBottom,
             'mdc-typography' . ($this->variant ? '--' . $this->variant : null)
         ]);
     }

--- a/src/Components/Typography.php
+++ b/src/Components/Typography.php
@@ -8,7 +8,6 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Typography extends Component
 {
-    public bool $gutterBottom;
     public ?string $element;
     public ?string $variant;
     public ?string $propSlot;
@@ -19,7 +18,7 @@ class Typography extends Component
      * @return void
      */
     public function __construct(
-        bool $gutterBottom = false,
+        private bool $disableGutter = false,
         ?string $element = null,
         ?string $slot = null,
         ?string $variant = null
@@ -27,7 +26,6 @@ class Typography extends Component
         [$elementTemp, $variant] = $this->variantPreprocess($variant);
 
         $this->element = $element ?: $elementTemp;
-        $this->gutterBottom = $gutterBottom;
         $this->variant = $variant;
         $this->propSlot = $slot;
     }
@@ -64,7 +62,7 @@ class Typography extends Component
     {
         return $attributes->class([
             'mbc-typography',
-            'mbc-typography--gutter-bottom' => $this->gutterBottom,
+            'mbc-typography--gutter-bottom' => !$this->disableGutter,
             'mdc-typography' . ($this->variant ? '--' . $this->variant : null)
         ]);
     }

--- a/src/Components/Typography.php
+++ b/src/Components/Typography.php
@@ -8,59 +8,59 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Typography extends Component
 {
-  public ?string $element;
-  public ?string $variant;
-  public ?string $propSlot;
+    public ?string $element;
+    public ?string $variant;
+    public ?string $propSlot;
 
-  /**
-   * Create a new component instance.
-   *
-   * @return void
-   */
-  public function __construct(
-    ?string $element = null,
-    ?string $slot = null,
-    ?string $variant = null
-  ) {
-    [$elementTemp, $variant] = $this->variantPreprocess($variant);
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        ?string $element = null,
+        ?string $slot = null,
+        ?string $variant = null
+    ) {
+        [$elementTemp, $variant] = $this->variantPreprocess($variant);
 
-    $this->element = $element ?: $elementTemp;
-    $this->variant = $variant;
-    $this->propSlot = $slot;
-  }
-
-  /**
-   * Get the view / contents that represent the component.
-   *
-   * @return \Illuminate\Contracts\View\View|\Closure|string
-   */
-  public function render()
-  {
-    return view('mbv::typography');
-  }
-
-  public function variantPreprocess(?string $variant)
-  {
-    if (in_array($variant, ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])) {
-      return [$variant, 'headline' . substr($variant, -1)];
+        $this->element = $element ?: $elementTemp;
+        $this->variant = $variant;
+        $this->propSlot = $slot;
     }
 
-
-    if (in_array($variant, ['subtitle1', 'subtitle2'])) {
-      return ['h6', $variant];
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return 'mbv::typography';
     }
 
-    if (!in_array($variant, ['body1', 'body2', 'button', 'caption', 'overline'])) {
-      $variant = null;
+    public function variantPreprocess(?string $variant)
+    {
+        if (in_array($variant, ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])) {
+            return [$variant, 'headline' . substr($variant, -1)];
+        }
+
+
+        if (in_array($variant, ['subtitle1', 'subtitle2'])) {
+            return ['h6', $variant];
+        }
+
+        if (!in_array($variant, ['body1', 'body2', 'button', 'caption', 'overline'])) {
+            $variant = null;
+        }
+
+        return ['p', $variant];
     }
 
-    return ['p', $variant];
-  }
-
-  public function attributesPreprocess(ComponentAttributeBag $attributes)
-  {
-    return $attributes->class([
-      'mdc-typography' . ($this->variant ? '--' . $this->variant : null)
-    ]);
-  }
+    public function attributesPreprocess(ComponentAttributeBag $attributes)
+    {
+        return $attributes->class([
+            'mdc-typography' . ($this->variant ? '--' . $this->variant : null)
+        ]);
+    }
 }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -4,28 +4,28 @@ namespace MaterialBlade;
 
 class Helper
 {
-  static function isThemeColor(string $colorText)
-  {
-    return in_array($colorText, ['primary', 'secondary', 'warning', 'error', 'success', 'info']);
-  }
-
-  static function getColor(string $colorText)
-  {
-    $isThemeColor = Self::isThemeColor($colorText);
-    return $isThemeColor ? 'var(--mdc-theme-' . $colorText . ')' : $colorText;
-  }
-
-  static function parseIconString(?string $iconText)
-  {
-    $icon = $iconText;
-    $variant = null;
-
-    $iconArr = explode(':', $iconText, 3);
-
-    if (count($iconArr) > 1) {
-      [$icon, $variant] = $iconArr;      
+    static function isThemeColor(string $colorText)
+    {
+        return in_array($colorText, ['primary', 'secondary', 'warning', 'error', 'success', 'info']);
     }
 
-    return [$icon, $variant];
-  }
+    static function getColor(string $colorText)
+    {
+        $isThemeColor = Self::isThemeColor($colorText);
+        return $isThemeColor ? 'var(--mdc-theme-' . $colorText . ')' : $colorText;
+    }
+
+    static function parseIconString(?string $iconText)
+    {
+        $icon = $iconText;
+        $variant = null;
+
+        $iconArr = explode(':', $iconText, 3);
+
+        if (count($iconArr) > 1) {
+            [$icon, $variant] = $iconArr;
+        }
+
+        return [$icon, $variant];
+    }
 }

--- a/src/MaterialBladeServiceProvider.php
+++ b/src/MaterialBladeServiceProvider.php
@@ -7,26 +7,26 @@ use Illuminate\Support\ServiceProvider;
 
 class MaterialBladeServiceProvider extends ServiceProvider
 {
-  /**
-   * Register any application services.
-   *
-   * @return void
-   */
-  public function register()
-  {
-    //
-  }
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
 
-  /**
-   * Bootstrap any application services.
-   *
-   * @return void
-   */
-  public function boot()
-  {
-    $this->loadViewsFrom(__DIR__ . '/views/components', 'mbv');
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/views/components', 'mbv');
 
-    Blade::componentNamespace('MaterialBlade\\Components', 'MaterialBlade');
-    Blade::componentNamespace('MaterialBlade\\Components', 'mbc');
-  }
+        Blade::componentNamespace('MaterialBlade\\Components', 'MaterialBlade');
+        Blade::componentNamespace('MaterialBlade\\Components', 'mbc');
+    }
 }

--- a/src/views/components/Grid/container.blade.php
+++ b/src/views/components/Grid/container.blade.php
@@ -1,0 +1,5 @@
+<div {{ $attributesPreprocess($attributes) }}>
+    <div class="mdc-layout-grid__inner">
+        {{ $slot }}
+    </div>
+</div>

--- a/src/views/components/Grid/item.blade.php
+++ b/src/views/components/Grid/item.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributesPreprocess($attributes) }}>
+    {{ $slot }}
+</div>

--- a/src/views/components/_assets.blade.php
+++ b/src/views/components/_assets.blade.php
@@ -1,6 +1,5 @@
 <link rel="stylesheet" href="https://unpkg.com/material-components-web@14.0.0/dist/material-components-web.min.css">
-<link rel="stylesheet"
-    href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp">
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp">
 
 <style>
     :root {
@@ -135,13 +134,214 @@
                 rgba(0, 0, 0, 0.24) 0%,
                 rgba(0, 0, 0, 0.24) 100%);
     }
+
+    .mbc-container {
+        margin: 0 auto;
+        padding: 0 1rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .mbc-container--xs {
+        max-width: 400px;
+    }
+
+    .mbc-container--sm {
+        max-width: 600px;
+    }
+
+    .mbc-container--md {
+        max-width: 800px;
+    }
+
+    .mbc-container--lg {
+        max-width: 1200px;
+    }
+
+    .mbc-container--xl {
+        max-width: 1400px;
+    }
+
+    .mbc-typography {
+        margin: 0;
+    }
+
+    .mbc-typography--gutter-bottom {
+        margin-bottom: 0.35em;
+    }
 </style>
 
-<script type="text/javascript"
-    src="https://unpkg.com/material-components-web@14.0.0/dist/material-components-web.min.js"></script>
+<script type="text/javascript" src="https://unpkg.com/material-components-web@14.0.0/dist/material-components-web.min.js"></script>
 
 <script>
-    document.addEventListener("DOMContentLoaded", function() {
-        @stack('MaterialBlade-scripts-on-ready')
-    });
+    function initAppBars() {
+        document.querySelectorAll('.mdc-top-app-bar').forEach(mdc.topAppBar.MDCTopAppBar.attachTo)
+    }
+
+    function initBanners() {
+        document.querySelectorAll('.mdc-banner').forEach(bannerEl => {
+            const buttons = bannerEl.querySelector('.mdc-banner__actions').querySelectorAll('button')
+            buttons.forEach(button => button.classList.add('mdc-banner__primary-action'))
+
+            bannerEl.mdc = new mdc.banner.MDCBanner(bannerEl)
+
+            bannerEl.mdc.open()
+
+            window.addEventListener("resize", () => {
+                bannerEl.mdc.layout()
+            })
+        })
+    }
+
+    function initButtons() {
+        const {
+            MDCRipple
+        } = mdc.ripple
+
+        document.querySelectorAll('.mdc-button').forEach(el => new MDCRipple(el))
+    }
+
+    function initCards() {
+        document.querySelectorAll('.mdc-card__action-buttons button').forEach(el => {
+            el.classList.add('mdc-card__action', 'mdc-card__action--button')
+        })
+
+        document.querySelectorAll('.mdc-card__action-icons button, .mdc-card__action-icons a').forEach(el => {
+            el.classList.add('mdc-card__action', 'mdc-card__action--icon')
+        })
+
+        document.querySelectorAll('.mdc-card__primary-action').forEach(el => {
+            mdc.ripple.MDCRipple.attachTo(el)
+        })
+    }
+
+    function initCheckBoxes() {
+        document.querySelectorAll('.mdc-checkbox').forEach(el => {
+            const checkbox = new mdc.checkbox.MDCCheckbox(el)
+            const formField = new mdc.formField.MDCFormField(el.parentElement)
+            formField.input = checkbox
+        })
+    }
+
+    function initChipSets() {
+        document.querySelectorAll('.mdc-chip-set').forEach(el => {
+            el.MDCChipSet = new mdc.chips.MDCChipSet(el)
+
+            el.MDCChipSet.listen('MDCChip:removal', event => {
+                console.log(event)
+                el.removeChild(event.detail.root)
+            })
+        })
+
+
+        // TODO: Add event listener for adding chips
+        // input.addEventListener('keydown', function(event) {
+        //     if (event.key === 'Enter' || event.keyCode === 13) {
+        //         const chipEl = document.createElement('div')
+
+        //         // ... perform operations to properly populate/decorate chip element ...
+        //         chipSetEl.appendChild(chipEl)
+        //         chipSet.addChip(chipEl)
+        //     }
+        // })
+    }
+
+    function initCircularProgresses() {
+        document.querySelectorAll('.mdc-circular-progress').forEach(el => {
+            el.circularProgress = new mdc.circularProgress.MDCCircularProgress(el)
+
+            if (value = el.getAttribute('aria-valuenow')) {
+                el.circularProgress.progress = value
+            }
+        })
+    }
+
+    function initDataTables() {
+        document.querySelectorAll('.mdc-data-table').forEach(el => {
+            el.MDCDataTable = new mdc.dataTable.MDCDataTable(el)
+        })
+    }
+
+    function initFabs() {
+        document.querySelectorAll('.mdc-fab').forEach(mdc.ripple.MDCRipple.attachTo)
+    }
+
+    function initIconButtons() {
+        document.querySelectorAll('.mdc-icon-button').forEach(button => {
+            if (button.querySelector('.mdc-icon-button__icon--on')) {
+                button.MDCIconButtonToggle = new mdc.iconButton.MDCIconButtonToggle(button)
+                return
+            }
+
+            if (button.querySelector('.mdc-icon-button__ripple')) {
+                button.MDCRipple = new mdc.ripple.MDCRipple(button)
+                button.MDCRipple.unbounded = true
+            }
+        })
+    }
+
+    function initLinearProgresses() {
+        document.querySelectorAll('.mdc-linear-progress').forEach(el => {
+            el.linearProgress = (new mdc.linearProgress.MDCLinearProgress(el))
+
+            if (value = el.getAttribute('aria-valuenow')) {
+                el.linearProgress.progress = value
+            }
+
+            if (el.dataset.bufferValue && el.dataset.bufferValue != 1) {
+                el.linearProgress.buffer = el.dataset.bufferValue
+            }
+        })
+    }
+
+    function initSnackbars() {
+        document.querySelectorAll('.mdc-snackbar').forEach(el => {
+            el.MDCSnackbar = new mdc.snackbar.MDCSnackbar(el)
+
+            if (el.hasAttribute('timeout')) {
+                el.MDCSnackbar.foundation.setTimeoutMs(el.getAttribute('timeout'))
+            }
+
+            if (el.hasAttribute('open')) {
+                el.MDCSnackbar.open()
+            }
+        })
+    }
+
+    function initSwitches() {
+        document.querySelectorAll('.mdc-switch').forEach(el => {
+            el.MDCSwitch = new mdc.switchControl.MDCSwitch(el)
+        })
+    }
+
+    function initTabBars() {
+        document.querySelectorAll('.mdc-tab-bar').forEach(el => {
+            el.MDCTabBar = new mdc.tabBar.MDCTabBar(el)
+        })
+    }
+
+    function initTooltips() {
+        document.querySelectorAll('.mdc-tooltip').forEach(el => {
+            el.MBC = new mdc.tooltip.MDCTooltip(el)
+        })
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        initBanners()
+        initAppBars()
+        initButtons()
+        initCards()
+        initCheckBoxes()
+        initChipSets()
+        initCircularProgresses()
+        initDataTables()
+        initFabs()
+        initIconButtons()
+        initLinearProgresses()
+        initSnackbars()
+        initSwitches()
+        initTabBars()
+        initTooltips()
+    })
 </script>

--- a/src/views/components/_assets.blade.php
+++ b/src/views/components/_assets.blade.php
@@ -25,9 +25,9 @@
         height: unset;
     }
 
-    .material-icons {
+    /* .material-icons {
         font-size: unset;
-    }
+    } */
 
     .mdc-banner .mdc-button:not(:disabled) {
         --mdc-text-button-label-text-color: var(--mdc-theme-primary);
@@ -257,6 +257,16 @@
         })
     }
 
+    function initDrawers() {
+        const {
+            MDCDrawer
+        } = mdc.drawer;
+
+        document.querySelectorAll('.mdc-drawer').forEach(el => {
+            el.MBC = MDCDrawer.attachTo(el)
+        })
+    }
+
     function initFabs() {
         document.querySelectorAll('.mdc-fab').forEach(mdc.ripple.MDCRipple.attachTo)
     }
@@ -286,6 +296,28 @@
             if (el.dataset.bufferValue && el.dataset.bufferValue != 1) {
                 el.linearProgress.buffer = el.dataset.bufferValue
             }
+        })
+    }
+
+    function initLists() {
+        const {
+            MDCRipple
+        } = mdc.ripple
+
+        const {
+            MDCList
+        } = mdc.list
+
+        document.querySelectorAll('.mdc-deprecated-list').forEach(el => {
+            el.MBC = new mdc.list.MDCList(el)
+            el.MBC.listElements.map((listItemEl) => new MDCRipple(listItemEl));
+
+            if (el.getAttribute('role') === 'listbox') {
+                el.MBC.singleSelection = true;
+            }
+
+            // exist on drawer fn
+            // list.wrapFocus = true;
         })
     }
 
@@ -333,6 +365,7 @@
         initFabs()
         initIconButtons()
         initLinearProgresses()
+        initLists()
         initSnackbars()
         initSwitches()
         initTabBars()

--- a/src/views/components/_assets.blade.php
+++ b/src/views/components/_assets.blade.php
@@ -49,12 +49,6 @@
         color: var(--mdc-theme-primary);
     }
 
-
-
-    .mdc-card {
-        max-width: 350px;
-    }
-
     .mdc-card__header * {
         margin: 0
     }

--- a/src/views/components/_assets.blade.php
+++ b/src/views/components/_assets.blade.php
@@ -156,14 +156,6 @@
     .mbc-container--xl {
         max-width: 1400px;
     }
-
-    .mbc-typography {
-        margin: 0;
-    }
-
-    .mbc-typography--gutter-bottom {
-        margin-bottom: 0.35em;
-    }
 </style>
 
 <script type="text/javascript" src="https://unpkg.com/material-components-web@14.0.0/dist/material-components-web.min.js"></script>

--- a/src/views/components/app-bar.blade.php
+++ b/src/views/components/app-bar.blade.php
@@ -3,23 +3,15 @@
     <div class="mdc-top-app-bar__row">
 
         @if ($start)
-            <div {{ $startAttributesPreprocess($start->attributes) }}>
-                {{ $start }}
-            </div>
+        <div {{ $startAttributesPreprocess($start->attributes) }}>
+            {{ $start }}
+        </div>
         @endif
 
         @isset($end)
-            <div {{ $endAttributesPreprocess($end->attributes) }}>
-                {{ $end }}
-            </div>
+        <div {{ $endAttributesPreprocess($end->attributes) }}>
+            {{ $end }}
+        </div>
         @endisset
     </div>
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-top-app-bar')].map(appBarTopEl => {
-        mdc.topAppBar.MDCTopAppBar.attachTo(appBarTopEl);
-        });
-    @endpush
-@endonce

--- a/src/views/components/banner.blade.php
+++ b/src/views/components/banner.blade.php
@@ -1,53 +1,31 @@
 <div {{ $attributesPreprocess($attributes) }}>
 
     @if ($isFixed)
-        <div class="mdc-banner__fixed">
-    @endif
-    <div class="mdc-banner__content" role="alertdialog" aria-live="assertive">
-        <div class="mdc-banner__graphic-text-wrapper">
+    <div class="mdc-banner__fixed">
+        @endif
+        <div class="mdc-banner__content" role="alertdialog" aria-live="assertive">
+            <div class="mdc-banner__graphic-text-wrapper">
 
-            @if ($icon)
+                @if ($icon)
                 <div class="mdc-banner__graphic" role="img" alt="">
                     <x-mbc::Icon class="mdc-banner__icon" :icon="$icon" />
                 </div>
-            @endif
+                @endif
 
-            <div class="mdc-banner__text">
-                {{ $text }}
+                <div class="mdc-banner__text">
+                    {{ $text }}
+                </div>
             </div>
-        </div>
 
-        @if ($slot)
+            @if ($slot)
             <div class="mdc-banner__actions">
 
                 {{ $slot }}
             </div>
-        @endif
-    </div>
-    
-    @if ($isFixed)
+            @endif
         </div>
+
+        @if ($isFixed)
+    </div>
     @endif
 </div>
-
-
-
-
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-banner')].map(bannerEl => {
-        buttons = [...bannerEl.querySelector('.mdc-banner__actions').querySelectorAll('button')];
-        buttons.forEach(button => button.classList.add('mdc-banner__primary-action'));
-
-        bannerEl.mdc = new mdc.banner.MDCBanner(bannerEl);
-
-        bannerEl.mdc.open();
-
-        window.addEventListener("resize", () => {
-        bannerEl.mdc.layout();
-        });
-
-        });
-    @endpush
-@endonce

--- a/src/views/components/button.blade.php
+++ b/src/views/components/button.blade.php
@@ -4,43 +4,35 @@ $attributes = $attributesPreprocess($attributes)->merge(['aria-label' => $label 
 ?>
 
 @if ($withWrapper)
-  <div class="mdc-touch-target-wrapper">
-@endif
+<div class="mdc-touch-target-wrapper">
+    @endif
 
-@if ($attributes->has('href'))
+    @if ($attributes->has('href'))
     <a {{ $attributes }}>
-@else
-    <button {{ $attributes }}>
-@endif
+        @else
+        <button {{ $attributes }}>
+            @endif
 
-@if ($isRipple)
-    <span class="mdc-button__ripple"></span>
-@endif
+            @if ($isRipple)
+            <span class="mdc-button__ripple"></span>
+            @endif
 
-@if ($startIcon)
-    <x-mbc::Icon :icon="$startIcon" class="mdc-button__icon" aria-hidden="true" />
-@endif
+            @if ($startIcon)
+            <x-mbc::Icon :icon="$startIcon" class="mdc-button__icon" aria-hidden="true" />
+            @endif
 
-<span class="mdc-button__label">{{ $label ?: $slot }}</span>
+            <span class="mdc-button__label">{{ $label ?: $slot }}</span>
 
-@if ($endIcon)
-    <x-mbc::Icon :icon="$endIcon" class="mdc-button__icon" aria-hidden="true" />
-@endif
+            @if ($endIcon)
+            <x-mbc::Icon :icon="$endIcon" class="mdc-button__icon" aria-hidden="true" />
+            @endif
 
-@if ($attributes->has('href'))
+            @if ($attributes->has('href'))
     </a>
-@else
+    @else
     </button>
-@endif
+    @endif
 
-@if ($withWrapper)
-  </div>
+    @if ($withWrapper)
+</div>
 @endif
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-button')].map(buttonEl => {
-        mdc.ripple.MDCRipple.attachTo(buttonEl)
-        });
-    @endpush
-@endonce

--- a/src/views/components/card-actions.blade.php
+++ b/src/views/components/card-actions.blade.php
@@ -1,25 +1,13 @@
 <div {{ $attributesPreprocess($attributes) }}>
     @if (isset($buttons))
-        <div {{ $buttons->attributes->class(['mdc-card__action-buttons']) }}>
-            {{ $buttons }}
-        </div>
+    <div {{ $buttons->attributes->class(['mdc-card__action-buttons']) }}>
+        {{ $buttons }}
+    </div>
     @endif
 
     @if (isset($iconButtons))
-        <div {{ $iconButtons->attributes->class(['mdc-card__action-icons']) }}>
-            {{ $iconButtons }}
-        </div>
+    <div {{ $iconButtons->attributes->class(['mdc-card__action-icons']) }}>
+        {{ $iconButtons }}
+    </div>
     @endif
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-card__action-buttons button')].map(el => {
-        el.classList.add('mdc-card__action', 'mdc-card__action--button')
-        });
-
-        [...document.querySelectorAll('.mdc-card__action-icons button, .mdc-card__action-icons a')].map(el => {
-        el.classList.add('mdc-card__action', 'mdc-card__action--icon');
-        });
-    @endpush
-@endonce

--- a/src/views/components/card-primary-action.blade.php
+++ b/src/views/components/card-primary-action.blade.php
@@ -1,13 +1,4 @@
 <div {{ $attributesPreprocess($attributes) }}>
-  {{ $slot }}
-  <div class="mdc-card__ripple"></div>
+    {{ $slot }}
+    <div class="mdc-card__ripple"></div>
 </div>
-
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-card__primary-action')].map(el => {
-        mdc.ripple.MDCRipple.attachTo(el);
-        });
-    @endpush
-@endonce

--- a/src/views/components/checkbox.blade.php
+++ b/src/views/components/checkbox.blade.php
@@ -3,8 +3,7 @@
     {{ $attributes->has('disabled') ? 'mdc-checkbox--disabled' : null }}
     ">
         <input {{ $attributesPreprocess($attributes) }} />
-        <div class="mdc-checkbox__background"
-            style="--mdc-checkbox-checked-color: {{ MaterialBlade\Helper::getColor($color) }}">
+        <div class="mdc-checkbox__background" style="--mdc-checkbox-checked-color: {{ MaterialBlade\Helper::getColor($color) }}">
             <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
                 <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
             </svg>
@@ -15,13 +14,3 @@
 
     <label for="{{ $attributes->get('id') }}">{{ $label }}</label>
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-checkbox')].map(checkboxEl => {
-        const checkbox = new mdc.checkbox.MDCCheckbox(checkboxEl);
-        const formField = new mdc.formField.MDCFormField(checkboxEl.parentElement);
-        formField.input = checkbox;
-        });
-    @endpush
-@endonce

--- a/src/views/components/chip-set.blade.php
+++ b/src/views/components/chip-set.blade.php
@@ -1,27 +1,3 @@
 <div {{ $attributesPreprocess($attributes) }}>
     {{ $slot }}
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-chip-set')].map(el => {
-        el.MDCChipSet = new mdc.chips.MDCChipSet(el);
-
-        el.MDCChipSet.listen('MDCChip:removal', event => {
-          console.log(event)
-        el.removeChild(event.detail.root);
-        });
-        });
-
-
-
-        {{-- input.addEventListener('keydown', function(event) {
-          if (event.key === 'Enter' || event.keyCode === 13) {
-            const chipEl = document.createElement('div');
-            // ... perform operations to properly populate/decorate chip element ...
-            chipSetEl.appendChild(chipEl);
-            chipSet.addChip(chipEl);
-          }
-        }); --}}
-    @endpush
-@endonce

--- a/src/views/components/circular-progress.blade.php
+++ b/src/views/components/circular-progress.blade.php
@@ -1,37 +1,36 @@
 @php
-  $wh = '48px';
-  $viewBox = '0 0 48 48';
-  $cx = 'cx="24" cy="24" r="18"';
-  $strokeWidth = 4;
-  $strokeWidth2 = 3.2;
-  $strokeDasharray = 113.097;
-  $strokeDashoffset = 56.549;
+$wh = '48px';
+$viewBox = '0 0 48 48';
+$cx = 'cx="24" cy="24" r="18"';
+$strokeWidth = 4;
+$strokeWidth2 = 3.2;
+$strokeDasharray = 113.097;
+$strokeDashoffset = 56.549;
 
-  if ($size === 'medium') {
-    $wh = '36px';
-    $viewBox = '0 0 32 32';
-    $cx = 'cx="16" cy="16" r="12.5"';
-    $strokeWidth = 3;
-    $strokeWidth2 = 2.4;
-    $strokeDasharray = 78.54;
-    $strokeDashoffset = 39.27;
-  }
+if ($size === 'medium') {
+$wh = '36px';
+$viewBox = '0 0 32 32';
+$cx = 'cx="16" cy="16" r="12.5"';
+$strokeWidth = 3;
+$strokeWidth2 = 2.4;
+$strokeDasharray = 78.54;
+$strokeDashoffset = 39.27;
+}
 
-  if ($size === 'small') {
-    $wh = '24px';
-    $viewBox = '0 0 24 24';
-    $cx = 'cx="12" cy="12" r="8.75"';
-    $strokeWidth = 2.5;
-    $strokeWidth2 = 2;
-    $strokeDasharray = 54.978;
-    $strokeDashoffset = 27.489;
-  }
+if ($size === 'small') {
+$wh = '24px';
+$viewBox = '0 0 24 24';
+$cx = 'cx="12" cy="12" r="8.75"';
+$strokeWidth = 2.5;
+$strokeWidth2 = 2;
+$strokeDasharray = 54.978;
+$strokeDashoffset = 27.489;
+}
 @endphp
 
 <div {{ $attributesPreprocess($attributes->merge(['style' => $attributes->prepends('width: ' . $wh . '; height: ' . $wh . ';')])) }}>
     <div class="mdc-circular-progress__determinate-container">
-        <svg class="mdc-circular-progress__determinate-circle-graphic" viewBox="{{ $viewBox }}"
-            xmlns="http://www.w3.org/2000/svg">
+        <svg class="mdc-circular-progress__determinate-circle-graphic" viewBox="{{ $viewBox }}" xmlns="http://www.w3.org/2000/svg">
             <circle class="mdc-circular-progress__determinate-track" {!! $cx !!} stroke-width="{{ $strokeWidth }}" />
             <circle class="mdc-circular-progress__determinate-circle" {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}" stroke-dashoffset="{{ $strokeDasharray }}" stroke-width="{{ $strokeWidth }}" />
         </svg>
@@ -39,41 +38,20 @@
     <div class="mdc-circular-progress__indeterminate-container">
         <div class="mdc-circular-progress__spinner-layer">
             <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-left">
-                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}"
-                        stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth }}" />
+                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}" xmlns="http://www.w3.org/2000/svg">
+                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}" stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth }}" />
                 </svg>
             </div>
             <div class="mdc-circular-progress__gap-patch">
-                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}"
-                        stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth2 }}" />
+                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}" xmlns="http://www.w3.org/2000/svg">
+                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}" stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth2 }}" />
                 </svg>
             </div>
             <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-right">
-                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}"
-                        stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth }}" />
+                <svg class="mdc-circular-progress__indeterminate-circle-graphic" viewBox="{{ $viewBox }}" xmlns="http://www.w3.org/2000/svg">
+                    <circle {!! $cx !!} stroke-dasharray="{{ $strokeDasharray }}" stroke-dashoffset="{{ $strokeDashoffset }}" stroke-width="{{ $strokeWidth }}" />
                 </svg>
             </div>
         </div>
     </div>
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-circular-progress')].map(el => {
-        const value =  el.getAttribute('aria-valuenow');
-
-        el.circularProgress = (new mdc.circularProgress.MDCCircularProgress(el));
-
-        if(value) {
-          el.circularProgress.progress = value
-        }
-
-        });
-    @endpush
-@endonce

--- a/src/views/components/data-table.blade.php
+++ b/src/views/components/data-table.blade.php
@@ -1,87 +1,77 @@
 <div {{ $attributes->class(['mdc-data-table']) }}>
     <div class="mdc-data-table__table-container">
-        <table class="mdc-data-table__table"{{ $attributes->has('aria-label') ? ' aria-label=' . $attributes->get('aria-label') : ''}}>
+        <table class="mdc-data-table__table" {{ $attributes->has('aria-label') ? ' aria-label=' . $attributes->get('aria-label') : ''}}>
             @if ($header)
-                <thead>
-                    <tr class="mdc-data-table__header-row">
-                        @if ($isWithCheckbox)
-                            <th class="mdc-data-table__header-cell mdc-data-table__header-cell--checkbox"
-                                role="columnheader" scope="col">
-                                <div class="mdc-checkbox mdc-data-table__header-row-checkbox">
-                                    <input type="checkbox" class="mdc-checkbox__native-control"
-                                        aria-label="Toggle all rows" />
-                                    <div class="mdc-checkbox__background">
-                                        <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                                            <path class="mdc-checkbox__checkmark-path" fill="none"
-                                                d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-                                        </svg>
-                                        <div class="mdc-checkbox__mixedmark"></div>
-                                    </div>
-                                    <div class="mdc-checkbox__ripple"></div>
-                                </div>
-                            </th>
-                        @endif
-                        @foreach ($header as $key => $col)
-                            <th class="mdc-data-table__header-cell{{ $col === 'numeric' ? ' mdc-data-table__header-cell--numeric' : null }}"
-                                role="columnheader" scope="col">{{ $col === 'numeric' ? $key : $col }}</th>
-                        @endforeach
-                    </tr>
-                </thead>
+            <thead>
+                <tr class="mdc-data-table__header-row">
+                    @if ($isWithCheckbox)
+                    <th class="mdc-data-table__header-cell mdc-data-table__header-cell--checkbox" role="columnheader" scope="col">
+                        <div class="mdc-checkbox mdc-data-table__header-row-checkbox">
+                            <input type="checkbox" class="mdc-checkbox__native-control" aria-label="Toggle all rows" />
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                            <div class="mdc-checkbox__ripple"></div>
+                        </div>
+                    </th>
+                    @endif
+                    @foreach ($header as $key => $col)
+                    <th class="mdc-data-table__header-cell{{ $col === 'numeric' ? ' mdc-data-table__header-cell--numeric' : null }}" role="columnheader" scope="col">{{ $col === 'numeric' ? $key : $col }}</th>
+                    @endforeach
+                </tr>
+            </thead>
             @endif
 
             @if ($tableData)
-                <tbody class="mdc-data-table__content">
-                    @foreach ($tableData as $row)
-                        @php
-                            $uuid = uniqid();
-                        @endphp
+            <tbody class="mdc-data-table__content">
+                @foreach ($tableData as $row)
+                @php
+                $uuid = uniqid();
+                @endphp
 
-                        <tr class="mdc-data-table__row"
-                            data-row-id="{{ $uuid }}"{{ $isWithCheckbox && $row[0] ? ' mdc-data-table__row--selected" aria-selected="true"' : '' }}>
-                            @if ($isWithCheckbox)
-                                <td class="mdc-data-table__cell mdc-data-table__cell--checkbox">
-                                    <div
-                                        class="mdc-checkbox mdc-data-table__row-checkbox{{ $row[0] ? ' mdc-checkbox--selected' : '' }}">
-                                        <input type="checkbox"
-                                            class="mdc-checkbox__native-control"{{ $row[0] ? ' checked' : '' }}
-                                            aria-labelledby="{{ $uuid }}" />
-                                        <div class="mdc-checkbox__background">
-                                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                                                <path class="mdc-checkbox__checkmark-path" fill="none"
-                                                    d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-                                            </svg>
-                                            <div class="mdc-checkbox__mixedmark"></div>
-                                        </div>
-                                        <div class="mdc-checkbox__ripple"></div>
-                                    </div>
-                                </td>
+                <tr class="mdc-data-table__row" data-row-id="{{ $uuid }}" {{ $isWithCheckbox && $row[0] ? ' mdc-data-table__row--selected" aria-selected="true"' : '' }}>
+                    @if ($isWithCheckbox)
+                    <td class="mdc-data-table__cell mdc-data-table__cell--checkbox">
+                        <div class="mdc-checkbox mdc-data-table__row-checkbox{{ $row[0] ? ' mdc-checkbox--selected' : '' }}">
+                            <input type="checkbox" class="mdc-checkbox__native-control" {{ $row[0] ? ' checked' : '' }} aria-labelledby="{{ $uuid }}" />
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                            <div class="mdc-checkbox__ripple"></div>
+                        </div>
+                    </td>
 
-                                @php
-                                    array_shift($row);
-                                @endphp
-                            @endif
+                    @php
+                    array_shift($row);
+                    @endphp
+                    @endif
 
-                            @foreach ($row as $key => $cell)
-                                @php
-                                    $el = 'td';
-                                    $scope = '';
-                                    
-                                    if ($loop->first) {
-                                        $el = 'th';
-                                        $scope = ' scope="row"';
-                                    }
-                                    
-                                    $classAdd = is_numeric($cell) ? ' mdc-data-table__cell--numeric' : '';
-                                @endphp
+                    @foreach ($row as $key => $cell)
+                    @php
+                    $el = 'td';
+                    $scope = '';
 
-                                <{{ $el }} id="{{ $uuid }}"
-                                    class="mdc-data-table__cell{{ $classAdd }}"{{ $scope }}>
-                                    {{ $cell }}
-                                    </{{ $el }}>
-                            @endforeach
-                        </tr>
+                    if ($loop->first) {
+                    $el = 'th';
+                    $scope = ' scope="row"';
+                    }
+
+                    $classAdd = is_numeric($cell) ? ' mdc-data-table__cell--numeric' : '';
+                    @endphp
+
+                    <{{ $el }} id="{{ $uuid }}" class="mdc-data-table__cell{{ $classAdd }}" {{ $scope }}>
+                        {{ $cell }}
+                    </{{ $el }}>
                     @endforeach
-                </tbody>
+                </tr>
+                @endforeach
+            </tbody>
         </table>
         @endif
     </div>
@@ -89,10 +79,3 @@
 
 {{-- TODO: data tabel with pagination --}}
 {{-- TODO: data tabel with progress indicator --}}
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-data-table')].map(el => {
-        el.MDCDataTable = new mdc.dataTable.MDCDataTable(el)
-        });
-    @endpush
-@endonce

--- a/src/views/components/data-table.blade.php
+++ b/src/views/components/data-table.blade.php
@@ -66,7 +66,7 @@
                     @endphp
 
                     <{{ $el }} id="{{ $uuid }}" class="mdc-data-table__cell{{ $classAdd }}" {{ $scope }}>
-                        {{ $cell }}
+                        {!! $cell !!}
                     </{{ $el }}>
                     @endforeach
                 </tr>

--- a/src/views/components/fab.blade.php
+++ b/src/views/components/fab.blade.php
@@ -1,31 +1,24 @@
 @if ($isWithWrapper)
-    <div class="mdc-touch-target-wrapper">
-@endif
+<div class="mdc-touch-target-wrapper">
+    @endif
 
-<button {{ $attributesPreprocess($attributes) }}>
-    <div class="mdc-fab__ripple"></div>
-    
-    @if ($iconString)
+    <button {{ $attributesPreprocess($attributes) }}>
+        <div class="mdc-fab__ripple"></div>
+
+        @if ($iconString)
         <x-mbc::Icon :icon="$iconString" class="mdc-fab__icon" />
-    @endif
+        @endif
 
-    @if ($label)
+        @if ($label)
         <span class="mdc-fab__label">{{ $label }}</span>
-    @endif
+        @endif
+
+        @if ($isWithWrapper)
+        <div class="mdc-fab__touch"></div>
+        @endif
+
+    </button>
 
     @if ($isWithWrapper)
-        <div class="mdc-fab__touch"></div>
-    @endif
-
-</button>
-
-@if ($isWithWrapper)
-    </div>
+</div>
 @endif
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-fab')].map(fabEl => {
-        mdc.ripple.MDCRipple.attachTo(fabEl);
-        });
-    @endpush
-@endonce

--- a/src/views/components/icon-button.blade.php
+++ b/src/views/components/icon-button.blade.php
@@ -7,61 +7,44 @@ $isDefaultColor = $color === 'var(--mdc-theme-text-secondary-on-light)';
 @endphp
 
 @if ($isWithWrapper)
-    <div class="mdc-touch-target-wrapper">
-@endif
+<div class="mdc-touch-target-wrapper">
+    @endif
 
-@if ($attributes->has('href') && !$isDisabled)
+    @if ($attributes->has('href') && !$isDisabled)
     <a {{ $attributes }}>
-    @else
+        @else
         <button {{ $attributes }}>
-@endif
+            @endif
 
-@if ($isRipple)
-    <div class="mdc-icon-button__ripple"></div>
-@endif
+            @if ($isRipple)
+            <div class="mdc-icon-button__ripple"></div>
+            @endif
 
-@if (!is_null($isToggle))
-    @php
-        $onColor = $isDefaultColor ? 'primary' : $color;
-        
-        if ($isDisabled) {
+            @if (!is_null($isToggle))
+            @php
+            $onColor = $isDefaultColor ? 'primary' : $color;
+
+            if ($isDisabled) {
             $onColor = null;
-        }
-    @endphp
-    <x-mbc::Icon class="mdc-icon-button__icon mdc-icon-button__icon--on" :icon="$icon" :color="$onColor" />
+            }
+            @endphp
+            <x-mbc::Icon class="mdc-icon-button__icon mdc-icon-button__icon--on" :icon="$icon" :color="$onColor" />
 
-    <x-mbc::Icon class="mdc-icon-button__icon" :icon="$offIcon ?: $icon" :color="$isDisabled ? null : ($offColor ?: $color)" />
-@else
-    <x-mbc::Icon :icon="$icon" :color="$isDisabled ? null : $color" />
-@endif
+            <x-mbc::Icon class="mdc-icon-button__icon" :icon="$offIcon ?: $icon" :color="$isDisabled ? null : ($offColor ?: $color)" />
+            @else
+            <x-mbc::Icon :icon="$icon" :color="$isDisabled ? null : $color" />
+            @endif
 
-@if ($isWithWrapper)
-    <div class="mdc-icon-button__touch"></div>
-@endif
+            @if ($isWithWrapper)
+            <div class="mdc-icon-button__touch"></div>
+            @endif
 
-@if ($attributes->has('href') && !$isDisabled)
+            @if ($attributes->has('href') && !$isDisabled)
     </a>
-@else
+    @else
     </button>
+    @endif
+
+    @if ($isWithWrapper)
+</div>
 @endif
-
-@if ($isWithWrapper)
-    </div>
-@endif
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-icon-button')].map(button => {
-
-        if (button.querySelector('.mdc-icon-button__icon--on')) {
-        return button.MDCIconButtonToggle = new mdc.iconButton.MDCIconButtonToggle(button);
-
-        }
-
-        if (button.querySelector('.mdc-icon-button__ripple')) {
-        button.MDCRipple = new mdc.ripple.MDCRipple(button)
-        return button.MDCRipple.unbounded = true
-        }
-        });
-    @endpush
-@endonce

--- a/src/views/components/linear-progress.blade.php
+++ b/src/views/components/linear-progress.blade.php
@@ -10,21 +10,3 @@
         <span class="mdc-linear-progress__bar-inner"></span>
     </div>
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-linear-progress')].map(el => {
-        const value =  el.getAttribute('aria-valuenow');
-
-        el.linearProgress = (new mdc.linearProgress.MDCLinearProgress(el));
-
-        if(value) {
-          el.linearProgress.progress = value
-        }
-
-        if(el.dataset.bufferValue && el.dataset.bufferValue != 1) {
-          el.linearProgress.buffer = el.dataset.bufferValue
-        }
-        });
-    @endpush
-@endonce

--- a/src/views/components/snackbar.blade.php
+++ b/src/views/components/snackbar.blade.php
@@ -7,25 +7,9 @@
         </div>
 
         @if (isset($action))
-            <div class="mdc-snackbar__actions" aria-atomic="true">
-                {{ $action }}
-            </div>
+        <div class="mdc-snackbar__actions" aria-atomic="true">
+            {{ $action }}
+        </div>
         @endif
     </div>
 </aside>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-snackbar')].map(el => {
-        el.MDCSnackbar = new mdc.snackbar.MDCSnackbar(el);
-
-        if (el.hasAttribute('timeout')) {
-        el.MDCSnackbar.foundation.setTimeoutMs(el.getAttribute('timeout'))
-        }
-
-        if (el.hasAttribute('open')) {
-        el.MDCSnackbar.open();
-        }
-        });
-    @endpush
-@endonce

--- a/src/views/components/switch.blade.php
+++ b/src/views/components/switch.blade.php
@@ -8,24 +8,16 @@
             <div class="mdc-switch__ripple"></div>
 
             @if ($icon || $offIcon)
-                <div class="mdc-switch__icons">
-                    @if ($icon)
-                        <x-mbc::Icon class="mdc-switch__icon mdc-switch__icon--on" color="#fff" :icon="$icon" />
-                    @endif
+            <div class="mdc-switch__icons">
+                @if ($icon)
+                <x-mbc::Icon class="mdc-switch__icon mdc-switch__icon--on" color="#fff" :icon="$icon" />
+                @endif
 
-                    @if ($offIcon)
-                        <x-mbc::Icon class="mdc-switch__icon mdc-switch__icon--off" color="#fff" :icon="$offIcon" />
-                    @endif
-                </div>
+                @if ($offIcon)
+                <x-mbc::Icon class="mdc-switch__icon mdc-switch__icon--off" color="#fff" :icon="$offIcon" />
+                @endif
+            </div>
             @endif
         </div>
     </div>
 </button>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-switch')].map(el => {
-        el.MDCSwitch = new mdc.switchControl.MDCSwitch(el);
-        });
-    @endpush
-@endonce

--- a/src/views/components/tab-bar.blade.php
+++ b/src/views/components/tab-bar.blade.php
@@ -1,58 +1,50 @@
 <div {{ $attributesPreprocess($attributes) }}>
-  <div class="mdc-tab-scroller">
-    <div class="mdc-tab-scroller__scroll-area">
-      <div class="mdc-tab-scroller__scroll-content">
-        @php
-          $tabCount = 0;
-        @endphp
-        @foreach ($tabs as $key => $tab)
+    <div class="mdc-tab-scroller">
+        <div class="mdc-tab-scroller__scroll-area">
+            <div class="mdc-tab-scroller__scroll-content">
+                @php
+                $tabCount = 0;
+                @endphp
+                @foreach ($tabs as $key => $tab)
 
-          @php
-            $tabCount++;
+                @php
+                $tabCount++;
 
-            $classAdd = '';
-            $isTabActive = false;
-            $icon = null;
-            
-            if($isFadeIndicator) {
-              $classAdd = ' mdc-tab-indicator--fade';
-            }
+                $classAdd = '';
+                $isTabActive = false;
+                $icon = null;
 
-            if ($activeTabNo === $tabCount || (!$activeTabNo && $loop->first)) {
-              $classAdd = ' mdc-tab-indicator--active';
-              $isTabActive = true;
-            }
-          @endphp
-          
-        <button class="mdc-tab{{ $isStacked ? ' mdc-tab--stacked' : '' }}{{ $isTabActive ? ' mdc-tab--active' : '' }}{{ $isLightText ? ' light-text' : '' }}"{{ $isTabActive ?  ' aria-selected="true"' : '' }} role="tab" tabindex="0">
-          <span class="mdc-tab__content">
-            @if (!is_int($key) || $isIconOnly)
-              <x-mbc::Icon aria-hidden="true" class="mdc-tab__icon" :icon="is_int($key) ? $tab : $key" style="font-size: 24px"/>
-            @endif
-            @if (!$isIconOnly)
-            <span class="mdc-tab__text-label">{{ $tab }}</span>
-            @endif
-          </span>
+                if($isFadeIndicator) {
+                $classAdd = ' mdc-tab-indicator--fade';
+                }
 
-          <span class="mdc-tab-indicator{{ $classAdd }}">
-            @if (isset($indicatorIcon))
-            <x-mbc::Icon aria-hidden="true" class="mdc-tab-indicator__content mdc-tab-indicator__content--icon" :icon="$indicatorIcon" style="font-size: 24px"/>
-            @else
-            <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
-            @endif
-          </span>
-          <span class="mdc-tab__ripple"></span>
-        </button>
-        @endforeach
-      </div>
+                if ($activeTabNo === $tabCount || (!$activeTabNo && $loop->first)) {
+                $classAdd = ' mdc-tab-indicator--active';
+                $isTabActive = true;
+                }
+                @endphp
+
+                <button class="mdc-tab{{ $isStacked ? ' mdc-tab--stacked' : '' }}{{ $isTabActive ? ' mdc-tab--active' : '' }}{{ $isLightText ? ' light-text' : '' }}" {{ $isTabActive ?  ' aria-selected="true"' : '' }} role="tab" tabindex="0">
+                    <span class="mdc-tab__content">
+                        @if (!is_int($key) || $isIconOnly)
+                        <x-mbc::Icon aria-hidden="true" class="mdc-tab__icon" :icon="is_int($key) ? $tab : $key" style="font-size: 24px" />
+                        @endif
+                        @if (!$isIconOnly)
+                        <span class="mdc-tab__text-label">{{ $tab }}</span>
+                        @endif
+                    </span>
+
+                    <span class="mdc-tab-indicator{{ $classAdd }}">
+                        @if (isset($indicatorIcon))
+                        <x-mbc::Icon aria-hidden="true" class="mdc-tab-indicator__content mdc-tab-indicator__content--icon" :icon="$indicatorIcon" style="font-size: 24px" />
+                        @else
+                        <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
+                        @endif
+                    </span>
+                    <span class="mdc-tab__ripple"></span>
+                </button>
+                @endforeach
+            </div>
+        </div>
     </div>
-  </div>
 </div>
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-tab-bar')].map(el => {
-        el.MDCTabBar = new mdc.tabBar.MDCTabBar(el);
-        });
-    @endpush
-@endonce

--- a/src/views/components/tooltip.blade.php
+++ b/src/views/components/tooltip.blade.php
@@ -1,6 +1,6 @@
 @isset($body)
-    <span class="mdc-tooltip-wrapper--rich">
-@endisset
+<span class="mdc-tooltip-wrapper--rich">
+    @endisset
     {!! $childPreprocess($slot->__tostring()) !!}
 
     <div {{ $attributesPreprocess($attributes)->class([
@@ -9,32 +9,24 @@
         <div class="mdc-tooltip__surface mdc-tooltip__surface-animation">
             @if(is_a($title, 'Illuminate\View\ComponentSlot'))
 
-                <h2 {{ $title->attributes->class(['mdc-tooltip__title']) }}>{{ $title }}</h2>
+            <h2 {{ $title->attributes->class(['mdc-tooltip__title']) }}>{{ $title }}</h2>
             @endif
 
             @isset($body)
-                <p {{ $body->attributes->class(['mdc-tooltip__content']) }}>
-                    {{ $body }}
-                </p>
+            <p {{ $body->attributes->class(['mdc-tooltip__content']) }}>
+                {{ $body }}
+            </p>
             @else
-                {{ $title }}
+            {{ $title }}
             @endisset
 
             @isset($action)
-                <span {{ $action->attributes->class(['mdc-tooltip--rich-actions']) }}>
-                    {{ $action }}
-                </span>
+            <span {{ $action->attributes->class(['mdc-tooltip--rich-actions']) }}>
+                {{ $action }}
+            </span>
             @endisset
         </div>
     </div>
-@isset($body)
-    </span>
+    @isset($body)
+</span>
 @endisset
-
-@once
-    @push('MaterialBlade-scripts-on-ready')
-        [...document.querySelectorAll('.mdc-tooltip')].map(tooltipEl => {
-        mdc.tooltip.MDCTooltip.attachTo(tooltipEl);
-        });
-    @endpush
-@endonce

--- a/src/views/components/typography.blade.php
+++ b/src/views/components/typography.blade.php
@@ -1,3 +1,3 @@
 <{{ $element }} {{ $attributesPreprocess($attributes) }}>
-    {{ trim($slot) ?: $propSlot }}
+    {{ $slot ?: $propSlot }}
 </{{ $element }}>


### PR DESCRIPTION
This pull request includes several commits that fix a type error and refactor the code. The changes include returning the name of the view instead of using the global helper `view`, adding the `gutterBottom` prop, adding the `Container` component, removing unnecessary code, adding the `Grid` component, allowing rendering of HTML inside `td`, adding the `Variant` enum, removing unset size for `.material-icons`, fixing an issue with rendering HTML in `$slot`, and updating the `Typography` component to use inline styles for margin and margin-bottom. The pull request also includes new files and updates to existing files.