### PR TITLE
Update lint command to use debug-check for Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "vite build --watch",
         "build": "tsc && vite build",
         "preview": "vite preview",
-        "lint": "prettier --check .",
+        "lint": "prettier --debug-check .",
         "lint:fix": "prettier --write .",
         "check:update": "ncu",
         "update": "ncu -u -t patch && npm update",


### PR DESCRIPTION
Change the lint command to utilize `--debug-check` for improved Prettier validation.